### PR TITLE
Replace PMError by NSError in the Readme and Documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,14 +46,14 @@ Create [PMPayment](http://paymill.github.io/paymill-ios/docs/sdk/Classes/PMPayme
 
 ```objective-c
  //init with PAYMILL public key  
- [PMManager initWithTestMode:YES merchantPublicKey:myPublicKey newDeviceId:nil init:^(BOOL success, PMError *error) {  
+ [PMManager initWithTestMode:YES merchantPublicKey:myPublicKey newDeviceId:nil init:^(BOOL success, NSError *error) {  
         if(success) {  
             // init successfull   
             // start using the SDK  
     }  
     }];
     
- PMError *error;  
+ NSError *error;  
  PMPaymentParams *params;  
  id paymentMethod = [PMFactory genCardPaymentWithAccHolder:@"Max Musterman" cardNumber:@"4711100000000000" expiryMonth:@"12" expiryYear:@"2014"  
  verification:@"333" error:&error];  
@@ -66,7 +66,7 @@ Create [PMPayment](http://paymill.github.io/paymill-ios/docs/sdk/Classes/PMPayme
      [PMManager generateTokenWithMethod:paymentMethod parameters:params success:^(NSString *token) {  
           //token successfully created  
      }  
-     failure:^(PMError *error) {  
+     failure:^(NSError *error) {  
           //token generation failed       
      }];  
  }   
@@ -78,14 +78,14 @@ To create transactions and preauthorizations directly from the SDK you first nee
 
 ```objective-c
  //init with PAYMILL public key  
- [PMManager initWithTestMode:YES merchantPublicKey:myPublicKey newDeviceId:nil init:^(BOOL success, PMError *error) {  
+ [PMManager initWithTestMode:YES merchantPublicKey:myPublicKey newDeviceId:nil init:^(BOOL success, NSError *error) {  
         if(success) {  
             // init successfull   
             // start using the SDK  
     }  
     }];
     
- PMError *error;  
+ NSError *error;  
  PMPaymentParams *params;  
  id paymentMethod = [PMFactory genCardPaymentWithAccHolder:@"Max Musterman" cardNumber:@"4711100000000000" expiryMonth:@"12" expiryYear:@"2014"  
  verification:@"333" error:&error];  
@@ -98,7 +98,7 @@ To create transactions and preauthorizations directly from the SDK you first nee
      [PMManager transactionWithMethod:paymentMethod parameters:params consumable:TRUE success:^(PMTransaction *transaction) {  
          // transaction successfully created  
      }  
-     failure:^(PMError *error) {  
+     failure:^(NSError *error) {  
         // transaction creation failed  
      }];  
  }     

--- a/samples/vouchermill/PayMillSDK/PayMillSDK.framework/Versions/A/Headers/PMFactory.h
+++ b/samples/vouchermill/PayMillSDK/PayMillSDK.framework/Versions/A/Headers/PMFactory.h
@@ -20,7 +20,7 @@
  @param expiryMonth credit card expiry month
  @param expiryYear credit card expiry year
  @param verification credit card verification number
- @param error PMError object
+ @param error NSError object
  @return PMPaymentMethod successfully created object
  */
 + (id<PMPaymentMethod>)genCardPaymentWithAccHolder:(NSString*)accHolder cardNumber:(NSString*)cardNumber expiryMonth:(NSString*) expiryMonth expiryYear:(NSString*)expiryYear verification:(NSString*)verification error:(NSError **)error;
@@ -30,7 +30,7 @@
  @param accountBank	bank code
  @param accountHolder first and second name of the account holder
  @param accountCountry	ISO 3166-2 formatted country code
- @param error PMError object
+ @param error NSError object
  @return PMPaymentMethod successfully created object
  */
 + (id<PMPaymentMethod>)genNationalPaymentWithAccNumber:(NSString *)accountNumber accBank:(NSString *)accountBank accHolder:(NSString *)accountHolder accCountry:(NSString *)accountCountry error:(NSError **)error;
@@ -40,7 +40,7 @@
  @param amount amount (in cents) which will be charged
  @param description	a short description for the transaction (e.g. shopping cart ID) or empty string or null.
  Note: You don't need to supply a description parameter when generating a token
- @param error PMError object
+ @param error NSError object
  @return PMPaymentParams successfully created object
  */
 + (PMPaymentParams*)genPaymentParamsWithCurrency:(NSString*)currency amount:(int)amount description:(NSString*)description error:(NSError **)error;
@@ -50,7 +50,7 @@
  @param accountBank	bank code
  @param accountHolder first and second name of the account holder
  @param accountCountry	ISO 3166-2 formatted country code
- @param error PMError object
+ @param error NSError object
  @return PMPaymentMethod successfully created object
  */
 + (id<PMPaymentMethod>)genNationalPaymentWithIban:(NSString *)accountIban andBic:(NSString *)accountBic accHolder:(NSString *)accountHolder error:(NSError **)error;

--- a/samples/vouchermill/README.md
+++ b/samples/vouchermill/README.md
@@ -28,7 +28,7 @@ API Docs for the Payment View Controller are available [here](http://paymill.git
 - Create the `PMPaymentParams` object that describes the amount, currency and description. Note, that you need to specify one, even if only generate a token.
 
 ```objective-c
-PMError *error;
+NSError *error;
 PMPaymentParams *pmParams = [PMFactory genPaymentParamsWithCurrency:@"EUR" amount:100 description:@"Description" error:&error];  
 ```
 
@@ -49,7 +49,7 @@ pmSettings.consumable = YES;
 id paymentViewController = [PMPaymentViewController alloc] initWithParams:pmParams publicKey:publicKey settings:pmSetings style:pmStyle 
 			success:^(id) {
 			//handle success
-			} failure:^(PMError *) {
+			} failure:^(NSError *) {
 			//handle error
 			}];
 ```
@@ -61,7 +61,7 @@ Complete example:
 ```objective-c
 -(void)test {
    //create payment params	 
-   PMError *error;
+   NSError *error;
    PMPaymentParams *pmParams = [PMFactory genPaymentParamsWithCurrency:@"EUR" amount:100 description:@"Description" error:&error];
    //create payment settings
    PMSettings pmSettings= [[PMSettings alloc] init];
@@ -76,7 +76,7 @@ Complete example:
 			   //handle success
 			   //since the payment type set in the settings is TOKEN, we expect a NSString to come back from PAYMILL
 		           token =  (NSString*)resObject;		
-			} failure:^(PMError *) {
+			} failure:^(NSError *) {
 			   //handle error
 			}];
    //present the view controller modally				


### PR DESCRIPTION
PMError has been replaced by NSError in the 1.1.0 release.
