### PR TITLE
use macos for osx public_header_files

### DIFF
--- a/PayMillSDK.podspec
+++ b/PayMillSDK.podspec
@@ -8,7 +8,8 @@ Pod::Spec.new do |s|
   s.source       = { :git => "https://github.com/paymill/paymill-ios.git", :tag => '2.2.0' }
   s.ios.deployment_target = '6.0'
   s.osx.deployment_target = '10.8'
-  s.public_header_files = 'samples/vouchermill/PayMillSDK/PayMillSDK.framework/Versions/A/Headers/*.h'
+  s.ios.public_header_files = 'samples/vouchermill/PayMillSDK/PayMillSDK.framework/Versions/A/Headers/*.h'
+  s.osx.public_header_files = 'macos/PayMillSDK.framework/Versions/A/Headers/*.h'
   s.ios.preserve_paths = 'samples/vouchermill/PayMillSDK/PayMillSDK.framework'
   s.osx.preserve_paths = 'macos/PayMillSDK.framework'
   s.ios.vendored_frameworks = 'samples/vouchermill/PayMillSDK/PayMillSDK.framework'


### PR DESCRIPTION
otherwise ```pod spec lint``` will fail with
```
- ERROR | [OSX] The  pattern did not match any file.
```